### PR TITLE
Remove UTF8 encoding/decoding of messagepack strings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2015-05-07 Mike Pye <mike@pusher.com>
+
+    * Remove coercion of msgpack String type to haskell Text
+
 2014-12-03 Sebastian Witte <woozletoff@gmail.com>
 
     * Add support for extension types

--- a/messagepack.cabal
+++ b/messagepack.cabal
@@ -1,5 +1,5 @@
 name               : messagepack
-version            : 0.3.0
+version            : 0.4.0
 synopsis           : Serialize instance for Message Pack Object
 description        : Serialize instance for Message Pack Object
 homepage           : https://github.com/rodrigosetti/messagepack
@@ -30,7 +30,6 @@ library
                    , bytestring == 0.10.*
                    , cereal     == 0.4.*
                    , containers == 0.5.*
-                   , text       == 1.*
 
 test-suite messagepack-tests
   type             : exitcode-stdio-1.0
@@ -45,6 +44,5 @@ test-suite messagepack-tests
                    , test-framework             == 0.8.*
                    , test-framework-quickcheck2 == 0.3.*
                    , test-framework-th          == 0.2.*
-                   , text                       == 1.*
                    , messagepack
 

--- a/msgpack.org.md
+++ b/msgpack.org.md
@@ -9,7 +9,7 @@ data Object = ObjectNil
             | ObjectBool   Bool
             | ObjectFloat  Float
             | ObjectDouble Double
-            | ObjectString Text
+            | ObjectString ByteString
             | ObjectBinary ByteString
             | ObjectArray  [Object]
             | ObjectMap    (M.Map Object Object )

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -9,7 +9,6 @@ import Test.Framework.TH
 import Test.QuickCheck
 import qualified Data.ByteString as BS
 import qualified Data.Map as M
-import qualified Data.Text as T
 
 main :: IO ()
 main = $(defaultMainGenerator)
@@ -44,12 +43,6 @@ instance Arbitrary BS.ByteString where
     arbitrary = BS.pack <$> arbitrary
 
     shrink = map BS.pack . shrink . BS.unpack
-
-instance Arbitrary T.Text where
-
-    arbitrary = T.pack <$> arbitrary
-
-    shrink = map T.pack . shrink . T.unpack
 
 prop_encodeDecodeIsIdentity :: Object -> Bool
 prop_encodeDecodeIsIdentity o = either error (== o) $ decode $ encode o


### PR DESCRIPTION
The MessagePack spec (https://github.com/msgpack/msgpack/blob/master/spec.md#type-system) specifies that the implementation should give access to the underlying byte array for String types, because the contents may not be valid.

We argue that the library should expose String fields as a `ByteString` in order to avoid invoking partial functions outside the control of the library user. If the user is confident that the String type will only encode UTF8 in their user case, or are happy to handle the exception, then they can use `decodeUtf8` themselves, but they should be given the choice.

Because of the history of the message pack spec (initially did not have a Binary type, Strings were used for arbitrary byte arrays) some encoders never use the Binary type, even when encoding arbitrary byte arrays.
