### PR TITLE
Introduce ObjectUInt constructor for messagepack unsigned ints

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2015-08-07 Will Sewell <will@pusher.com>
+
+    * Add ObjectUInt constructor for messagepack unsigned ints
+
 2015-05-07 Mike Pye <mike@pusher.com>
 
     * Remove coercion of msgpack String type to haskell Text

--- a/messagepack.cabal
+++ b/messagepack.cabal
@@ -1,5 +1,5 @@
 name               : messagepack
-version            : 0.4.0
+version            : 0.5.0
 synopsis           : Serialize instance for Message Pack Object
 description        : Serialize instance for Message Pack Object
 homepage           : https://github.com/rodrigosetti/messagepack

--- a/msgpack.org.md
+++ b/msgpack.org.md
@@ -5,6 +5,7 @@ This implementation defines an messagepack `Object` type, which is an instance o
 
 ```haskell
 data Object = ObjectNil
+            | ObjectUInt   Word64
             | ObjectInt    Int64
             | ObjectBool   Bool
             | ObjectFloat  Float

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -15,6 +15,7 @@ main = $(defaultMainGenerator)
 
 instance Arbitrary Object where
     arbitrary = sized $ \n -> oneof [ return ObjectNil
+                                    , ObjectUInt   <$> arbitrary
                                     , ObjectInt    <$> arbitrary
                                     , ObjectBool   <$> arbitrary
                                     , ObjectFloat  <$> arbitrary


### PR DESCRIPTION
The messagepack protocol supports 64-bit unsigned integers. This library converts all messagepack integers into Int64. This is a problem because 64-bit unsigned integers can hold a larger range of numbers than 64-bit signed integers.

For this reason we have introduced an ObjectWord Word64 value constructor that is used to store messagepack unsigned integers.