### PR TITLE
Add NFData instance

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2016-11-29 Sebastian Witte <woozletoff@gmail.com>
+
+    * Add NFData instance
+
 2015-11-03 Rodrigo Setti <rodrigosetti@gmail.com>
 
     * Updates cereal to 0.5.0.0

--- a/Data/MessagePack.hs
+++ b/Data/MessagePack.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-|
 Module      : Data.MessagePack
 Description : Object data type with Serialize instances for it
@@ -16,7 +17,9 @@ deserialized to message pack binary format, following the specification.
 module Data.MessagePack where
 
 import Control.Applicative
+import Control.DeepSeq (NFData)
 import Control.Monad
+import GHC.Generics (Generic)
 import Data.Bits
 import Data.Int
 import Data.MessagePack.Spec
@@ -38,7 +41,9 @@ data Object = ObjectNil
             | ObjectArray  [Object]
             | ObjectMap    (M.Map Object Object )
             | ObjectExt    !Int8 BS.ByteString
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Show, Generic)
+
+instance NFData Object
 
 instance Serialize Object where
     put (ObjectUInt i)

--- a/messagepack.cabal
+++ b/messagepack.cabal
@@ -1,5 +1,5 @@
 name               : messagepack
-version            : 0.5.3
+version            : 0.5.4
 synopsis           : Serialize instance for Message Pack Object
 description        : Serialize instance for Message Pack Object
 homepage           : https://github.com/rodrigosetti/messagepack

--- a/messagepack.cabal
+++ b/messagepack.cabal
@@ -29,6 +29,7 @@ library
                    , bytestring == 0.10.*
                    , cereal     == 0.5.*
                    , containers == 0.5.*
+                   , deepseq
 
 test-suite messagepack-tests
   type             : exitcode-stdio-1.0


### PR DESCRIPTION
I have an [interesting bug](https://github.com/neovimhaskell/nvim-hs/issues/48) that can be fixed rather easily if the `Object` data type had an NFData instance.

I don't see any reason not to include it, so it would be great if you could release a new version which includes this pull request. :-)