### PR TITLE
Relax dependency bounds and remove test-framework dependency

### DIFF
--- a/messagepack.cabal
+++ b/messagepack.cabal
@@ -1,5 +1,5 @@
 name               : messagepack
-version            : 0.5.4
+version            : 0.5.5
 synopsis           : Serialize instance for Message Pack Object
 description        : Serialize instance for Message Pack Object
 homepage           : https://github.com/rodrigosetti/messagepack
@@ -25,11 +25,11 @@ library
   exposed-modules  : Data.MessagePack
                    , Data.MessagePack.Spec
   default-language : Haskell2010
-  build-depends    : base       >= 4.6 && <5
-                   , bytestring == 0.10.*
-                   , cereal     == 0.5.*
-                   , containers >= 0.5 && <0.7
-                   , deepseq    >= 1.1 && <1.5
+  build-depends    : base       >= 4.6
+                   , bytestring >= 0.10
+                   , cereal     >= 0.5
+                   , containers >= 0.5
+                   , deepseq    >= 1.1
  other-extensions  : DeriveGeneric
 
 test-suite messagepack-tests
@@ -37,13 +37,10 @@ test-suite messagepack-tests
   hs-source-dirs   : tests
   main-is          : Main.hs
   default-language : Haskell2010
-  build-depends    : base                       == 4.*
-                   , QuickCheck                 == 2.*
-                   , bytestring                 == 0.10.*
-                   , cereal                     == 0.5.*
-                   , containers                 >= 0.5 && <0.7
-                   , test-framework             == 0.8.*
-                   , test-framework-quickcheck2 == 0.3.*
-                   , test-framework-th          == 0.2.*
+  build-depends    : base                       >= 4
+                   , QuickCheck                 >= 2
+                   , bytestring                 >= 0.10
+                   , cereal                     >= 0.5
+                   , containers                 >= 0.5
                    , messagepack
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-12-25
+resolver: nightly-2022-03-19
 
 packages:
 - '.'

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -4,14 +4,9 @@ module Main where
 import Control.Applicative
 import Data.MessagePack
 import Data.Serialize
-import Test.Framework.Providers.QuickCheck2
-import Test.Framework.TH
 import Test.QuickCheck
 import qualified Data.ByteString as BS
 import qualified Data.Map as M
-
-main :: IO ()
-main = $(defaultMainGenerator)
 
 instance Arbitrary Object where
     arbitrary = sized $ \n -> oneof [ return ObjectNil
@@ -42,3 +37,6 @@ instance Arbitrary BS.ByteString where
 prop_encodeDecodeIsIdentity :: Object -> Bool
 prop_encodeDecodeIsIdentity o = either error (== o) $ decode $ encode o
 
+return []
+main :: IO Bool
+main = $quickCheckAll


### PR DESCRIPTION
This package has been removed from stackage nightly because it has unneccessarily tight version bounds.

>     - messagepack < 0 # tried messagepack-0.5.4, but its *library* does not support: bytestring-0.11.3.0

I don't think the upper bounds are necessary to define because they are unknown and you will be notified by the stackage if something isn't compatible anymore and then the bounds can be adjusted on hackage after the fact.

When trying to run the tests, I noticed that the `test-framework`-dependencies were not useful, so i removed them.